### PR TITLE
[Feature] Add support for multiple oracle sources per token in Scope program

### DIFF
--- a/programs/scope/src/errors.rs
+++ b/programs/scope/src/errors.rs
@@ -102,6 +102,18 @@ pub enum ScopeError {
 
     #[msg("Confidence interval check failed")]
     ConfidenceIntervalCheckFailed,
+
+    #[msg("Invalid source index")]
+    InvalidSourceIndex,
+
+    #[msg("Price data is stale")]
+    PriceStale,
+
+    #[msg("Unauthorized access")]
+    Unauthorized,
+
+    #[msg("Invalid token metadata value")]
+    InvalidTokenMetadataValue,
 }
 
 impl<T> From<TryFromPrimitiveError<T>> for ScopeError

--- a/programs/scope/src/handlers/handler_initialize.rs
+++ b/programs/scope/src/handlers/handler_initialize.rs
@@ -13,7 +13,14 @@ pub struct Initialize<'info> {
 
     // Set space to max size here
     // The ability to create multiple feeds is mostly useful for tests
-    #[account(init, seeds = [seeds::CONFIG, feed_name.as_bytes()], bump, payer = admin, space = 8 + std::mem::size_of::<crate::Configuration>())]
+    #[account(
+        init,
+        seeds = [seeds::ORACLE_MAPPINGS, feed_name.as_bytes()],
+        bump,
+        payer = admin,
+        space = 8 + ORACLE_MAPPING_SIZE,
+    )]
+    pub oracle_mappings: AccountLoader<'info, crate::OracleMappings>,
     pub configuration: AccountLoader<'info, crate::Configuration>,
 
     #[account(zero)]

--- a/programs/scope/src/states.rs
+++ b/programs/scope/src/states.rs
@@ -136,12 +136,12 @@ pub struct OracleMappings {
 }
 
 impl OracleMappings {
-    pub fn is_twap_enabled(&self, entry_id: usize) -> bool {
-        self.twap_enabled[entry_id] > 0
+    pub fn is_twap_enabled(&self, entry_id: usize, source_idx: usize) -> bool {
+        self.twap_enabled[entry_id][source_idx] > 0
     }
 
-    pub fn get_twap_source(&self, entry_id: usize) -> usize {
-        usize::from(self.twap_source[entry_id])
+    pub fn get_twap_source(&self, entry_id: usize, source_idx: usize) -> usize {
+        usize::from(self.twap_source[entry_id][source_idx])
     }
 }
 


### PR DESCRIPTION
**Overview:**
Added a feature by allowing each token to have multiple oracle sources. This adds redundancy and improves reliability by enabling the protocol to use alternative price feeds if one fails or provides invalid data. This actually happening recently in some Solana projects.

**Changes:**
Updated the `OracleMappings` struct to support multiple oracle accounts per token.
Modified handlers to accommodate the new structure, including `handler_update_mapping.rs` and `handler_refresh_prices.rs`.
Adjusted methods and logic to iterate over multiple sources and select valid prices.
Added error handling for invalid source indices.
Adjusted account sizes.

**Testing:**
Added unit tests for the new functionality. (on local)
Performed integration tests to verify correct behavior.