### PR TITLE
Release 0.39.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "scope"
-version = "0.37.0"
+version = "0.39.0"
 dependencies = [
  "adrena-perp-itf",
  "anchor-lang",

--- a/configs/mainnet/3NJYftD5sjVfxSnUdZ1wVML8f3aC6mp1CXCL6L7TnU8C.json
+++ b/configs/mainnet/3NJYftD5sjVfxSnUdZ1wVML8f3aC6mp1CXCL6L7TnU8C.json
@@ -406,7 +406,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 2398,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50,
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50,
     "max_age_slot": 375,
     "group_ids": [ 2 ],
     "twap_enabled": ["1h"]
@@ -1169,7 +1170,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 6,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50,
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50,
     "group_ids": [ 1 ],
     "ref_price": 0,
     "ref_price_tolerance_bps": 500
@@ -1179,7 +1181,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50,
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50,
     "group_ids": [ 1 ],
     "ref_price": 2,
     "ref_price_tolerance_bps": 500
@@ -1251,7 +1254,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 7,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 100,
+    "bid_ask_spread_factor": 100,
+    "price_confidence_factor": 100,
     "group_ids": [ 1 ]
   },
   "309": {
@@ -1309,7 +1313,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 2,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50,
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50,
     "group_ids": [ 1 ]
   },
   "323": {
@@ -1317,7 +1322,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 8,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 100,
+    "bid_ask_spread_factor": 100,
+    "price_confidence_factor": 100,
     "group_ids": [ 1 ]
   },
   "324": {

--- a/configs/mainnet/3t4JZcueEzTbVP6kLxXrL3VpWx45jDer4eqysweBchNH.json
+++ b/configs/mainnet/3t4JZcueEzTbVP6kLxXrL3VpWx45jDer4eqysweBchNH.json
@@ -3,11 +3,6 @@
     "__note": "The top-level `__docs` element is not parsed by any logic, and exists only to provide a place for documenting things specific to this file. It would not be needed if JSON supported comments."
   },
   "default_max_age": 160,
-  "0": {
-    "label": "Pyth Pull SOL/USD",
-    "oracle_mapping": "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE",
-    "oracle_type": "PythPull"
-  },
   "1": {
     "label": "Chainlink SOL/USD",
     "oracle_type": "Chainlink",
@@ -15,12 +10,16 @@
     "confidence_factor": 50,
     "twap_enabled": ["1h"]
   },
+  
   "2": {
     "label": "PythLazer SOL/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 6,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50,
+    "ema_enabled": true,
+    "ema_confidence_factor": 50
   },
   "3": {
     "label": "Most recent SOL/USD",
@@ -51,18 +50,17 @@
     "oracle_type": "Chainlink",
     "chainlink_feed_id": "0x00038f83323b6b08116d1614cf33a9bd71ab5e0abf0c9f1b783a74a43e7bd992",
     "confidence_factor": 200,
-    "ref_price": 6,
-    "twap_enabled": ["1h"],
-    "ref_price_tolerance_bps": 500
+    "twap_enabled": ["1h"]
   },
   "8": {
     "label": "PythLazer USDC/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 7,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 100,
-    "ref_price": 6,
-    "ref_price_tolerance_bps": 500
+    "bid_ask_spread_factor": 100,
+    "price_confidence_factor": 100,
+    "ema_enabled": true,
+    "ema_confidence_factor": 200
   },
   "9": {
     "label": "Most recent USDC/USD",
@@ -166,21 +164,6 @@
     "oracle_mapping": "DJ2FyTgUAkEtXW3U5P9PF19meFTRtW4ZWKKFgACfVbUy",
     "oracle_type": "PythPull"
   },
-  "27": {
-    "label": "Pyth Pull EMA AAPL/USD",
-    "oracle_mapping": "DJ2FyTgUAkEtXW3U5P9PF19meFTRtW4ZWKKFgACfVbUy",
-    "oracle_type": "PythPullEMA"
-  },
-  "28": {
-    "label": "Pyth Pull AAPLx/AAPL",
-    "oracle_mapping": "4vuxa9hrEi3uWZinS3K3tGvFu9fx6KJuefgdoaoBefLS",
-    "oracle_type": "PythPull"
-  },
-  "29": {
-    "label": "Pyth Pull EMA AAPLx/AAPL",
-    "oracle_mapping": "4vuxa9hrEi3uWZinS3K3tGvFu9fx6KJuefgdoaoBefLS",
-    "oracle_type": "PythPullEMA"
-  },
   "30": {
     "label": "Chainlink AAPLx/USD Open",
     "oracle_type": "ChainlinkRWA",
@@ -204,21 +187,6 @@
     "label": "Pyth Pull GOOGL/USD",
     "oracle_mapping": "HShKFQqhYkUiXpVyyLmrAALXwWqHB7ikLmPbrwJzpRNh",
     "oracle_type": "PythPull"
-  },
-  "35": {
-    "label": "Pyth Pull EMA GOOGL/USD",
-    "oracle_mapping": "HShKFQqhYkUiXpVyyLmrAALXwWqHB7ikLmPbrwJzpRNh",
-    "oracle_type": "PythPullEMA"
-  },
-  "36": {
-    "label": "Pyth Pull GOOGLx/GOOGL",
-    "oracle_mapping": "5KtoPy9WsV2tg87qQbpPFPJeTyDyyvnaurqeiwk1f3Ks",
-    "oracle_type": "PythPull"
-  },
-  "37": {
-    "label": "Pyth Pull EMA GOOGLx/GOOGL",
-    "oracle_mapping": "5KtoPy9WsV2tg87qQbpPFPJeTyDyyvnaurqeiwk1f3Ks",
-    "oracle_type": "PythPullEMA"
   },
   "38": {
     "label": "Chainlink GOOGLx/USD Open",
@@ -244,21 +212,6 @@
     "oracle_mapping": "2w1Tg1XTZbUib7srfRoStJ4v5JXVsK7roQEGMsMaGZFC",
     "oracle_type": "PythPull"
   },
-  "43": {
-    "label": "Pyth Pull EMA NVDA/USD",
-    "oracle_mapping": "2w1Tg1XTZbUib7srfRoStJ4v5JXVsK7roQEGMsMaGZFC",
-    "oracle_type": "PythPullEMA"
-  },
-  "44": {
-    "label": "Pyth Pull NVDAx/NVDA",
-    "oracle_mapping": "9Qxr7ZFsMCoA7Yo1vEMc23mqeZX5qx6xBo5jbHgVHKir",
-    "oracle_type": "PythPull"
-  },
-  "45": {
-    "label": "Pyth Pull EMA NVDAx/NVDA",
-    "oracle_mapping": "9Qxr7ZFsMCoA7Yo1vEMc23mqeZX5qx6xBo5jbHgVHKir",
-    "oracle_type": "PythPullEMA"
-  },
   "46": {
     "label": "Chainlink NVDAx/USD Open",
     "oracle_type": "ChainlinkRWA",
@@ -282,11 +235,6 @@
     "label": "Pyth Pull AMZN/USD",
     "oracle_mapping": "GBkjjFxbaFY9TBHpAPypk5JBchpPPve2jskAcd9zuFNd",
     "oracle_type": "PythPull"
-  },
-  "51": {
-    "label": "Pyth Pull EMA AMZN/USD",
-    "oracle_mapping": "GBkjjFxbaFY9TBHpAPypk5JBchpPPve2jskAcd9zuFNd",
-    "oracle_type": "PythPullEMA"
   },
   "52": {
     "label": "Chainlink AMZNx/USD Open",
@@ -312,21 +260,6 @@
     "oracle_mapping": "E8WFH8brgP58arcuW2wwsPHiomYrSvrgWTsRLZLAEZUQ",
     "oracle_type": "PythPull"
   },
-  "57": {
-    "label": "Pyth Pull EMA TSLA/USD",
-    "oracle_mapping": "E8WFH8brgP58arcuW2wwsPHiomYrSvrgWTsRLZLAEZUQ",
-    "oracle_type": "PythPullEMA"
-  },
-  "58": {
-    "label": "Pyth Pull TSLAx/TSLA",
-    "oracle_mapping": "4a4TAWMimr7GHbWPpKtHTqGhgagVTCW5rAN9PprM6NEJ",
-    "oracle_type": "PythPull"
-  },
-  "59": {
-    "label": "Pyth Pull EMA TSLAx/TSLA",
-    "oracle_mapping": "4a4TAWMimr7GHbWPpKtHTqGhgagVTCW5rAN9PprM6NEJ",
-    "oracle_type": "PythPullEMA"
-  },
   "60": {
     "label": "Chainlink TSLAx/USD Open",
     "oracle_type": "ChainlinkRWA",
@@ -351,21 +284,6 @@
     "oracle_mapping": "91JXaWGHr57awfqhXQP2TxrkLX6CpvtBaaRjz1PEQqXn",
     "oracle_type": "PythPull"
   },
-  "65": {
-    "label": "Pyth Pull EMA COIN/USD",
-    "oracle_mapping": "91JXaWGHr57awfqhXQP2TxrkLX6CpvtBaaRjz1PEQqXn",
-    "oracle_type": "PythPullEMA"
-  },
-  "66": {
-    "label": "Pyth Pull COINx/COIN",
-    "oracle_mapping": "4S9Labj9bT2CqRJb5uc36x54gZoN8JBc6eJYLTB2orBx",
-    "oracle_type": "PythPull"
-  },
-  "67": {
-    "label": "Pyth Pull EMA COINx/COIN",
-    "oracle_mapping": "4S9Labj9bT2CqRJb5uc36x54gZoN8JBc6eJYLTB2orBx",
-    "oracle_type": "PythPullEMA"
-  },
   "68": {
     "label": "Chainlink COINx/USD Open",
     "oracle_type": "ChainlinkRWA",
@@ -389,21 +307,6 @@
     "label": "Pyth Pull MSTR/USD",
     "oracle_mapping": "HJGvGyWrAXdZPG4Q7LNkkKja72FDkJW7ixuyg3u6vZyP",
     "oracle_type": "PythPull"
-  },
-  "73": {
-    "label": "Pyth Pull EMA MSTR/USD",
-    "oracle_mapping": "HJGvGyWrAXdZPG4Q7LNkkKja72FDkJW7ixuyg3u6vZyP",
-    "oracle_type": "PythPullEMA"
-  },
-  "74": {
-    "label": "Pyth Pull MSTRx/MSTR",
-    "oracle_mapping": "5cWXcVyw5LWfvKjUHm6PKnfEfbW9C6bYSHRGhiU7hZC1",
-    "oracle_type": "PythPull"
-  },
-  "75": {
-    "label": "Pyth Pull EMA MSTRx/MSTR",
-    "oracle_mapping": "5cWXcVyw5LWfvKjUHm6PKnfEfbW9C6bYSHRGhiU7hZC1",
-    "oracle_type": "PythPullEMA"
   },
   "76": {
     "label": "Chainlink MSTRx/USD Open",
@@ -443,16 +346,6 @@
     "market_status_behavior": "AllUpdates",
     "twap_enabled": ["1h"]
   },
-  "84": {
-    "label": "Pyth Pull SPYx/SPY",
-    "oracle_mapping": "2if3wciQYbmgCzicHgofw2NFA6YHAQHxQKxzSZWb8Cpg",
-    "oracle_type": "PythPull"
-  },
-  "85": {
-    "label": "Pyth Pull EMA SPYx/SPY",
-    "oracle_mapping": "2if3wciQYbmgCzicHgofw2NFA6YHAQHxQKxzSZWb8Cpg",
-    "oracle_type": "PythPullEMA"
-  },
   "86": {
     "label": "Chainlink QQQx/USD Open",
     "oracle_type": "ChainlinkRWA",
@@ -477,40 +370,10 @@
     "oracle_mapping": "EwssJrQ7UVz6itHEaQQsKWikhZ3iHddyxRhmR7pTvwt5",
     "oracle_type": "PythPull"
   },
-  "91": {
-    "label": "Pyth Pull EMA QQQ/USD",
-    "oracle_mapping": "EwssJrQ7UVz6itHEaQQsKWikhZ3iHddyxRhmR7pTvwt5",
-    "oracle_type": "PythPullEMA"
-  },
-  "92": {
-    "label": "Pyth Pull QQQx/QQQ",
-    "oracle_mapping": "BYaWQnztYwBDPvH2m7yTGRx3TdSumGcu9ocCPhQ4HHdk",
-    "oracle_type": "PythPull"
-  },
-  "93": {
-    "label": "Pyth Pull EMA QQQx/QQQ",
-    "oracle_mapping": "BYaWQnztYwBDPvH2m7yTGRx3TdSumGcu9ocCPhQ4HHdk",
-    "oracle_type": "PythPullEMA"
-  },
   "94": {
     "label": "Pyth Pull HOOD/USD",
     "oracle_mapping": "5tZizzQN776ZWTibPJKecjk1DkTSDHu47dXM3SxR5D5i",
     "oracle_type": "PythPull"
-  },
-  "95": {
-    "label": "Pyth Pull EMA HOOD/USD",
-    "oracle_mapping": "5tZizzQN776ZWTibPJKecjk1DkTSDHu47dXM3SxR5D5i",
-    "oracle_type": "PythPullEMA"
-  },
-  "96": {
-    "label": "Pyth Pull HOODx/HOOD",
-    "oracle_mapping": "BkLXe2FGM8udS2GMewjoYbmLjxKhfApEXYyYR2yKzAj3",
-    "oracle_type": "PythPull"
-  },
-  "97": {
-    "label": "Pyth Pull EMA HOODx/HOOD",
-    "oracle_mapping": "BkLXe2FGM8udS2GMewjoYbmLjxKhfApEXYyYR2yKzAj3",
-    "oracle_type": "PythPullEMA"
   },
   "98": {
     "label": "Chainlink HOODx/USD Open",
@@ -626,9 +489,10 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 8,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 200,
-    "ref_price": 14,
-    "ref_price_tolerance_bps": 500
+    "bid_ask_spread_factor": 200,
+    "price_confidence_factor": 200,
+    "ema_enabled": true,
+    "ema_confidence_factor": 200
   },
   "120": {
     "label": "Most recent USDT/USD",
@@ -649,9 +513,10 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 88,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 200,
-    "ref_price": 20,
-    "ref_price_tolerance_bps": 500
+    "bid_ask_spread_factor": 200,
+    "price_confidence_factor": 200,
+    "ema_enabled": true,
+    "ema_confidence_factor": 200
   },
   "124": {
     "label": "Most recent FDUSD/USD",
@@ -665,9 +530,10 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 232,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 200,
-    "ref_price": 23,
-    "ref_price_tolerance_bps": 500
+    "bid_ask_spread_factor": 200,
+    "price_confidence_factor": 200,
+    "ema_enabled": true,
+    "ema_confidence_factor": 200
   },
   "126": {
     "label": "Most recent USDG/USD",
@@ -688,11 +554,6 @@
     "chainlink_feed_id": "0x0003a910a43485e0685ff5d6d366541f5c21150f0634c5b14254392d1a1c06db",
     "confidence_factor": 200,
     "twap_enabled": ["1h"]
-  },
-  "130": {
-    "label": "PythPull BTC/USD",
-    "oracle_mapping": "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
-    "oracle_type": "PythPull"
   },
   "131": {
     "label": "PythPull EMA BTC/USD",
@@ -722,9 +583,7 @@
     "oracle_type": "MostRecentOf",
     "sources_max_age_s": 7200,
     "max_divergence_bps": 50,
-    "source_entries": [17, 134],
-    "ref_price": 17,
-    "ref_price_tolerance_bps": 500
+    "source_entries": [17, 134]
   },
   "136": {
     "label": "Chainlink FDUSD/USD",
@@ -738,11 +597,6 @@
     "oracle_mapping": "Cr8vurLth4b7CFNdvoXDpxuRi21CWvbQFLKy8BTwN4Wf",
     "oracle_type": "PythPull"
   },
-  "138": {
-    "label": "Pyth Pull EMA USDE/USD",
-    "oracle_mapping": "Cr8vurLth4b7CFNdvoXDpxuRi21CWvbQFLKy8BTwN4Wf",
-    "oracle_type": "PythPullEMA"
-  },
   "139": {
     "label": "Chainlink USDE/USD",
     "oracle_type": "Chainlink",
@@ -755,9 +609,10 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 204,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 100,
-    "ref_price": 137,
-    "ref_price_tolerance_bps": 500
+    "bid_ask_spread_factor": 100,
+    "price_confidence_factor": 100,
+    "ema_enabled": true,
+    "ema_confidence_factor": 200
   },
   "141": {
     "label": "Most recent USDE/USD",
@@ -794,9 +649,10 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 156,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 100,
-    "ref_price": 143,
-    "ref_price_tolerance_bps": 500
+    "bid_ask_spread_factor": 100,
+    "price_confidence_factor": 100,
+    "ema_enabled": true,
+    "ema_confidence_factor": 200
   },
   "147": {
     "label": "Most recent PYUSD/USD",
@@ -852,9 +708,7 @@
     "oracle_type": "MostRecentOf",
     "sources_max_age_s": 7200,
     "max_divergence_bps": 50,
-    "source_entries": [153, 154],
-    "ref_price": 154,
-    "ref_price_tolerance_bps": 500
+    "source_entries": [153, 465]
   },
   "157": {
     "label": "Capped USX/USD",
@@ -886,20 +740,10 @@
     "oracle_mapping": "2uPQGpm8X4ZkxMHxrAW1QuhXcse1AHEgPih6Xp9NuEWW",
     "oracle_type": "PythPull"
   },
-  "162": {
-    "label": "Pyth Pull EMA XAU/USD",
-    "oracle_mapping": "2uPQGpm8X4ZkxMHxrAW1QuhXcse1AHEgPih6Xp9NuEWW",
-    "oracle_type": "PythPullEMA"
-  },
   "163": {
     "label": "Pyth Pull XAUT/USD",
     "oracle_mapping": "6aLRPrkf5SM4mZdQCbb23YMZirN8bX7pqbbk1mZfb1s9",
     "oracle_type": "PythPull"
-  },
-  "164": {
-    "label": "Pyth Pull EMA XAUT/USD",
-    "oracle_mapping": "6aLRPrkf5SM4mZdQCbb23YMZirN8bX7pqbbk1mZfb1s9",
-    "oracle_type": "PythPullEMA"
   },
   "165": {
     "label": "Chainlink XAUT/USD",
@@ -961,7 +805,10 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50,
+    "ema_enabled": true,
+    "ema_confidence_factor": 50
   },
   "175": {
     "label": "Most recent BTC/USD",
@@ -995,16 +842,6 @@
     "oracle_mapping": "84NBovYcdtTdbb9vw9U7YeGPssTuCxcAMexw3PWDzWhR",
     "oracle_type": "PythPullEMA"
   },
-  "180": {
-    "label": "Pyth Pull GLXY/USD Equity.US",
-    "oracle_mapping": "EHEfCJoRUewTW91Lv2k33eLW72JkbxbVH6YsisTskg1n",
-    "oracle_type": "PythPull"
-  },
-  "181": {
-    "label": "Pyth Pull GLXY/USD SS RR",
-    "oracle_mapping": "3uvvRXgBetb19nJKb9pRxvKL3YCZy7XcLdaRbFd7Wxcw",
-    "oracle_type": "PythPull"
-  },
   "182": {
     "label": "Pyth Pull FORD/USD Index",
     "oracle_mapping": "GUq4JEVMgC5AmZpKxjh1aJsabB9X7mBwPavKSsnz11DS",
@@ -1014,16 +851,6 @@
     "label": "Pyth Pull EMA FORD/USD Index",
     "oracle_mapping": "GUq4JEVMgC5AmZpKxjh1aJsabB9X7mBwPavKSsnz11DS",
     "oracle_type": "PythPullEMA"
-  },
-  "184": {
-    "label": "Pyth Pull FORD/USD Equity.US",
-    "oracle_mapping": "6hZRbSdvdAM6smU8mmQjx7rr1wp9RGLzRp4dao4kMms6",
-    "oracle_type": "PythPull"
-  },
-  "185": {
-    "label": "Pyth Pull FORD/USD SS RR",
-    "oracle_mapping": "FZWSpPPteGgPeNv3kugyZZoRZNzswfi1qNipHT1DtjMa",
-    "oracle_type": "PythPull"
   },
   "186": {
     "label": "stkeSOL/SOL",
@@ -1102,9 +929,7 @@
     "oracle_type": "Chainlink",
     "chainlink_feed_id": "0x000325435d5067ffedaa6d41639f96c129eb7ceae2b9b56acace2e8e948d4959",
     "confidence_factor": 200,
-    "ref_price": 196,
-    "twap_enabled": ["1h"],
-    "ref_price_tolerance_bps": 500
+    "twap_enabled": ["1h"]
   },
   "199": {
     "label": "Chainlink TWAP USD1/USD",
@@ -1117,9 +942,10 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 604,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 100,
-    "ref_price": 196,
-    "ref_price_tolerance_bps": 500
+    "bid_ask_spread_factor": 100,
+    "price_confidence_factor": 100,
+    "ema_enabled": true,
+    "ema_confidence_factor": 200
   },
   "201": {
     "label": "Most recent USD1/USD",
@@ -1450,11 +1276,6 @@
     "oracle_mapping": "w1sgiDz1vsb3GqHLbe58DeBHXCh4JpgWxu5Ko3fiGv7",
     "oracle_type": "PythPull"
   },
-  "250": {
-    "label": "Pyth Pull EMA eUSX/USX RR",
-    "oracle_mapping": "w1sgiDz1vsb3GqHLbe58DeBHXCh4JpgWxu5Ko3fiGv7",
-    "oracle_type": "PythPullEMA"
-  },
   "251": {
     "label": "Most recent eUSX/USX",
     "oracle_type": "MostRecentOf",
@@ -1506,7 +1327,7 @@
     "oracle_type": "ChainlinkX",
     "chainlink_feed_id": "0x000a7a12270b5a30236bf410679df0c6bb1bba2b40e5d86847748ff1c8f8452b",
     "market_status_behavior": "AllUpdates",
-    "ref_price": 26,
+    "ref_price": 409,
     "twap_enabled": ["1h"],
     "ref_price_tolerance_bps": 500
   },
@@ -1521,7 +1342,7 @@
     "oracle_type": "ChainlinkX",
     "chainlink_feed_id": "0x000a2349781696825299ea1610f3ed0f47c5e7585003a271417f6e94778020fe",
     "market_status_behavior": "AllUpdates",
-    "ref_price": 94,
+    "ref_price": 420,
     "twap_enabled": ["1h"],
     "ref_price_tolerance_bps": 500
   },
@@ -1549,7 +1370,7 @@
     "oracle_type": "ChainlinkX",
     "chainlink_feed_id": "0x000a724ccab2a885eaeb8d56c54eda31f467564681f6e8dd32c5b64d40110054",
     "market_status_behavior": "AllUpdates",
-    "ref_price": 34,
+    "ref_price": 410,
     "twap_enabled": ["1h"],
     "ref_price_tolerance_bps": 500
   },
@@ -1577,7 +1398,7 @@
     "oracle_type": "ChainlinkX",
     "chainlink_feed_id": "0x000a37a55df2ef907d8fa06af6632bc16da58a62b68be2e1994efaa037a0918a",
     "market_status_behavior": "AllUpdates",
-    "ref_price": 42,
+    "ref_price": 411,
     "twap_enabled": ["1h"],
     "ref_price_tolerance_bps": 500
   },
@@ -1592,7 +1413,7 @@
     "oracle_type": "ChainlinkX",
     "chainlink_feed_id": "0x000a7b26938f7df83a0bd00f76b0f644a6ef4f28b5cbb9afb800fbcdc8536255",
     "market_status_behavior": "AllUpdates",
-    "ref_price": 72,
+    "ref_price": 415,
     "twap_enabled": ["1h"],
     "ref_price_tolerance_bps": 500
   },
@@ -1607,7 +1428,7 @@
     "oracle_type": "ChainlinkX",
     "chainlink_feed_id": "0x000a80c655069b61d168b887d5e7f4231fe288c6ccb84b1854c9ccead20f3398",
     "market_status_behavior": "AllUpdates",
-    "ref_price": 56,
+    "ref_price": 413,
     "twap_enabled": ["1h"],
     "ref_price_tolerance_bps": 500
   },
@@ -1622,7 +1443,7 @@
     "oracle_type": "ChainlinkX",
     "chainlink_feed_id": "0x000a67e280bea6fbdb91dd827763f915a62d880bf055c04dcd63a101f1545682",
     "market_status_behavior": "AllUpdates",
-    "ref_price": 50,
+    "ref_price": 412,
     "twap_enabled": ["1h"],
     "ref_price_tolerance_bps": 500
   },
@@ -1637,7 +1458,7 @@
     "oracle_type": "ChainlinkX",
     "chainlink_feed_id": "0x000a9811a9bef734e52059c184312bd9ebf24b3ce5f86285f693eacbb7151baa",
     "market_status_behavior": "AllUpdates",
-    "ref_price": 64,
+    "ref_price": 414,
     "twap_enabled": ["1h"],
     "ref_price_tolerance_bps": 500
   },
@@ -1652,7 +1473,7 @@
     "oracle_type": "ChainlinkX",
     "chainlink_feed_id": "0x000ac6ba1b453a15c1fe9dcd82265ca47bcd04e7b3667de1623617c45cef2a77",
     "market_status_behavior": "AllUpdates",
-    "ref_price": 284,
+    "ref_price": 417,
     "twap_enabled": ["1h"],
     "ref_price_tolerance_bps": 500
   },
@@ -1667,7 +1488,7 @@
     "oracle_type": "ChainlinkX",
     "chainlink_feed_id": "0x000a1db22e3e1aa657d910dc90e1f0dbe693d345b7b0b04fd9efc8eb17aef267",
     "market_status_behavior": "AllUpdates",
-    "ref_price": 90,
+    "ref_price": 418,
     "twap_enabled": ["1h"],
     "ref_price_tolerance_bps": 500
   },
@@ -1719,26 +1540,6 @@
     "twap_source": 286,
     "max_age_slot": 165
   },
-  "289": {
-    "label": "Pyth Pull USR/USD RR",
-    "oracle_mapping": "8Wbhnq9YzgFsigwBdDPuCbLCBKyZeQSfmk5XfRByDmcX",
-    "oracle_type": "PythPull"
-  },
-  "290": {
-    "label": "Pyth Pull EMA USR/USD RR",
-    "oracle_mapping": "8Wbhnq9YzgFsigwBdDPuCbLCBKyZeQSfmk5XfRByDmcX",
-    "oracle_type": "PythPullEMA"
-  },
-  "291": {
-    "label": "Pyth Pull wstUSR/USR RR",
-    "oracle_mapping": "8mKWjTDrR3k9pahmJcR7ZyyYThtjGHZeENFRwn4HqhwC",
-    "oracle_type": "PythPull"
-  },
-  "292": {
-    "label": "Pyth Pull EMA wstUSR/USR RR",
-    "oracle_mapping": "8mKWjTDrR3k9pahmJcR7ZyyYThtjGHZeENFRwn4HqhwC",
-    "oracle_type": "PythPullEMA"
-  },
   "293": {
     "label": "Chainlink dejAAA/USD NAV",
     "oracle_type": "ChainlinkExchangeRate",
@@ -1751,16 +1552,6 @@
     "twap_source": 293,
     "max_age_slot": 165
   },
-  "295": {
-    "label": "Pyth Pull dejAAA/USD NAV",
-    "oracle_mapping": "G7ycRzKBSLMfqotmH6kXysEvoK8U3A2rcPsEwZmYghbh",
-    "oracle_type": "PythPull"
-  },
-  "296": {
-    "label": "Pyth Pull EMA dejAAA/USD NAV",
-    "oracle_mapping": "G7ycRzKBSLMfqotmH6kXysEvoK8U3A2rcPsEwZmYghbh",
-    "oracle_type": "PythPullEMA"
-  },
   "297": {
     "label": "Chainlink dejTRSY/USD NAV",
     "oracle_type": "ChainlinkExchangeRate",
@@ -1772,16 +1563,6 @@
     "oracle_type": "ScopeTwap1h",
     "twap_source": 297,
     "max_age_slot": 165
-  },
-  "299": {
-    "label": "Pyth Pull dejTRSY/USD NAV",
-    "oracle_mapping": "7eWZ4sEsVqN56VHGu5tNrFEA4q6HKpzN9s89kRM85F1E",
-    "oracle_type": "PythPull"
-  },
-  "300": {
-    "label": "Pyth Pull EMA dejTRSY/USD NAV",
-    "oracle_mapping": "7eWZ4sEsVqN56VHGu5tNrFEA4q6HKpzN9s89kRM85F1E",
-    "oracle_type": "PythPullEMA"
   },
   "301": {
     "label": "Chainlink USX/USD NAV",
@@ -1857,7 +1638,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 2941,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "313": {
     "label": "MostRecent syrupUSDC/USD",
@@ -1878,7 +1660,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1792,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "316": {
     "label": "MostRecent AAPLx/USD",
@@ -1899,7 +1682,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1815,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "319": {
     "label": "MostRecent HOODx/USD",
@@ -1920,7 +1704,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1798,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "322": {
     "label": "MostRecent CRCLx/USD",
@@ -1941,7 +1726,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1808,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "325": {
     "label": "MostRecent GOOGLx/USD",
@@ -1962,7 +1748,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1824,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "328": {
     "label": "MostRecent METAx/USD",
@@ -1983,7 +1770,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1833,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "331": {
     "label": "MostRecent NVDAx/USD",
@@ -2004,7 +1792,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1827,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "334": {
     "label": "MostRecent MSTRx/USD",
@@ -2025,7 +1814,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1847,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "337": {
     "label": "MostRecent TSLAx/USD",
@@ -2046,7 +1836,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1796,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "340": {
     "label": "MostRecent COINx/USD",
@@ -2067,7 +1858,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1843,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "343": {
     "label": "MostRecent SPYx/USD",
@@ -2088,7 +1880,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1837,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "346": {
     "label": "MostRecent QQQx/USD",
@@ -2354,7 +2147,8 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 2419,
     "pyth_lazer_exponent": 5,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "400": {
     "label": "Exponent PT-2609/eUSX",
@@ -2398,112 +2192,128 @@
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 276,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "407": {
     "label": "PythLazer ZEC/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 66,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "408": {
     "label": "PythLazer HYPE/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 110,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "409": {
     "label": "PythLazer AAPL/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 922,
     "pyth_lazer_exponent": 5,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "410": {
     "label": "PythLazer GOOGL/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1163,
     "pyth_lazer_exponent": 5,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "411": {
     "label": "PythLazer NVDA/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1314,
     "pyth_lazer_exponent": 5,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "412": {
     "label": "PythLazer AMZN/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 954,
     "pyth_lazer_exponent": 5,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "413": {
     "label": "PythLazer TSLA/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1435,
     "pyth_lazer_exponent": 5,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "414": {
     "label": "PythLazer COIN/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1042,
     "pyth_lazer_exponent": 5,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "415": {
     "label": "PythLazer MSTR/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1294,
     "pyth_lazer_exponent": 5,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "416": {
     "label": "PythLazer META/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1272,
     "pyth_lazer_exponent": 5,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "417": {
     "label": "PythLazer SPY/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1398,
     "pyth_lazer_exponent": 5,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "418": {
     "label": "PythLazer QQQ/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1363,
     "pyth_lazer_exponent": 5,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "419": {
     "label": "PythLazer CRCL/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1683,
     "pyth_lazer_exponent": 5,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "420": {
     "label": "PythLazer HOOD/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 1182,
     "pyth_lazer_exponent": 5,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "422": {
     "label": "PythLazer XAUT/USD",
     "oracle_type": "PythLazer",
     "pyth_lazer_feed_id": 172,
     "pyth_lazer_exponent": 8,
-    "confidence_factor": 50
+    "bid_ask_spread_factor": 50,
+    "price_confidence_factor": 50
   },
   "423": {
     "label": "Chainlink AUTO/wYLDS",
@@ -2690,6 +2500,100 @@
     "source_entry": 450,
     "cap_entry": 423,
     "floor_entry": 423
+  },
+  "452": {
+    "label": "Chainlink GBP/USD AllUpdates",
+    "oracle_type": "ChainlinkRWA",
+    "chainlink_feed_id": "0x00086bdceb0b66669c04e7315815614f4ad910e6bb0134e2a7b9070145eb2e7b",
+    "market_status_behavior": "AllUpdates",
+    "twap_enabled": ["1h"]
+  },
+  "453": {
+    "label": "TWAP CL GBP/USD AllUpdates",
+    "oracle_type": "ScopeTwap1h",
+    "twap_source": 452,
+    "max_age_slot": 165
+  },
+  "454": {
+    "label": "Checked PAXG/USD",
+    "oracle_type": "CappedFloored",
+    "source_entry": 444,
+    "cap_entry": 167,
+    "floor_entry": 167
+  },
+  "455": {
+    "label": "PythLazerEMA SOL/USD",
+    "oracle_type": "PythLazerEMA",
+    "pyth_lazer_ema_source_entry": 2
+  },
+  "456": {
+    "label": "PythLazerEMA USDC/USD",
+    "oracle_type": "PythLazerEMA",
+    "pyth_lazer_ema_source_entry": 8
+  },
+  "457": {
+    "label": "PythLazerEMA USDT/USD",
+    "oracle_type": "PythLazerEMA",
+    "pyth_lazer_ema_source_entry": 119
+  },
+  "458": {
+    "label": "PythLazerEMA FDUSD/USD",
+    "oracle_type": "PythLazerEMA",
+    "pyth_lazer_ema_source_entry": 123
+  },
+  "459": {
+    "label": "PythLazerEMA USDG/USD",
+    "oracle_type": "PythLazerEMA",
+    "pyth_lazer_ema_source_entry": 125
+  },
+  "460": {
+    "label": "PythLazerEMA USDE/USD",
+    "oracle_type": "PythLazerEMA",
+    "pyth_lazer_ema_source_entry": 140
+  },
+  "461": {
+    "label": "PythLazerEMA PYUSD/USD",
+    "oracle_type": "PythLazerEMA",
+    "pyth_lazer_ema_source_entry": 146
+  },
+  "462": {
+    "label": "PythLazerEMA BTC/USD",
+    "oracle_type": "PythLazerEMA",
+    "pyth_lazer_ema_source_entry": 174
+  },
+  "463": {
+    "label": "PythLazerEMA USD1/USD",
+    "oracle_type": "PythLazerEMA",
+    "pyth_lazer_ema_source_entry": 200
+  },
+  "464": {
+    "label": "PythLazer USDS/USD",
+    "oracle_type": "PythLazer",
+    "pyth_lazer_feed_id": 611,
+    "pyth_lazer_exponent": 8,
+    "bid_ask_spread_factor": 100,
+    "price_confidence_factor": 100
+  },
+  "465": {
+    "label": "PythLazer USX/USD",
+    "oracle_type": "PythLazer",
+    "pyth_lazer_feed_id": 1851,
+    "pyth_lazer_exponent": 8,
+    "bid_ask_spread_factor": 100,
+    "price_confidence_factor": 100
+  },
+  "466": {
+    "label": "Chainlink oTFY/USD",
+    "oracle_type": "ChainlinkNAV",
+    "chainlink_feed_id": "0x0009bf088582463ee42e21e75e7ba2f16833fe3fce402b9af9556f3c57411689",
+    "twap_enabled": ["1h"],
+    "ref_price": 12,
+    "ref_price_tolerance_bps": 200
+  },
+  "467": {
+    "label": "TWAP Chainlink oTFY/USD",
+    "oracle_type": "ScopeTwap1h",
+    "twap_source": 466,
+    "max_age_slot": 165
   }
 }
-

--- a/programs/scope/Cargo.toml
+++ b/programs/scope/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scope"
-version = "0.37.0"
+version = "0.39.0"
 description = "Scope is Kamino's oracle aggregator"
 repository = "https://github.com/Kamino-Finance/scope"
 edition = "2021"

--- a/programs/scope/src/errors.rs
+++ b/programs/scope/src/errors.rs
@@ -223,6 +223,12 @@ pub enum ScopeError {
 
     #[msg("PythLazerEMA source entry does not have EMA enabled")]
     PythLazerEmaNotEnabledOnSource,
+
+    #[msg("Signer is not authorized to resume")]
+    UnauthorizedResume,
+
+    #[msg("Property fields in the feed of the PythLazer payload do not contain a confidence")]
+    PythLazerConfidenceNotPresent,
 }
 
 impl<T> From<TryFromPrimitiveError<T>> for ScopeError

--- a/programs/scope/src/handlers/handler_freeze_price.rs
+++ b/programs/scope/src/handlers/handler_freeze_price.rs
@@ -7,26 +7,10 @@ use crate::{
     ScopeError, MAX_ENTRIES,
 };
 
-/// Check if the authority is allowed to freeze/unfreeze prices.
-/// Admin can freeze and unfreeze; emergency council can only freeze.
-fn is_allowed_authority(
-    authority: &Signer,
-    configuration: &AccountLoader<Configuration>,
-    freeze: bool,
-) -> Result<bool> {
-    let config = configuration.load()?;
-    let authority = authority.key();
-    let is_admin = authority == config.admin;
-    let is_emergency_council =
-        authority == config.emergency_council && config.emergency_council != Pubkey::default();
-
-    Ok(is_admin || (is_emergency_council && freeze))
-}
-
 #[derive(Accounts)]
 #[instruction(token: u16, feed_name: String, freeze: bool)]
 pub struct FreezePrice<'info> {
-    #[account(constraint = is_allowed_authority(&authority, &configuration, freeze)? @ ScopeError::UnauthorizedFreeze)]
+    #[account(constraint = configuration.load()?.can_freeze(&authority.key(), freeze) @ ScopeError::UnauthorizedFreeze)]
     pub authority: Signer<'info>,
 
     #[account(seeds = [seeds::CONFIG, feed_name.as_bytes()], bump, has_one = oracle_mappings)]

--- a/programs/scope/src/handlers/handler_initialize.rs
+++ b/programs/scope/src/handlers/handler_initialize.rs
@@ -60,6 +60,9 @@ pub fn process(ctx: Context<Initialize>, _: String) -> Result<()> {
     configuration.oracle_twaps = twaps_pbk;
     configuration.tokens_metadata = metadata_pbk;
     configuration.admin_cached = Pubkey::default();
+    // Start with no ops delegates set (default pubkey = admin-only freeze/resume).
+    configuration.emergency_council = Pubkey::default();
+    configuration.resume_authority = Pubkey::default();
 
     // Initialize oracle twap account
     oracle_twaps.oracle_prices = prices_pbk;

--- a/programs/scope/src/handlers/handler_refresh_pyth_lazer_price.rs
+++ b/programs/scope/src/handlers/handler_refresh_pyth_lazer_price.rs
@@ -83,6 +83,9 @@ pub fn refresh_pyth_lazer_price<'info>(
     let oracle_mappings = ctx.accounts.oracle_mappings.load()?;
     let mut oracle_prices = ctx.accounts.oracle_prices.load_mut()?;
 
+    // In case only one token is provided fail the whole transaction if the price is not valid
+    let fail_tx_on_error = tokens.len() == 1;
+
     for (i, &token) in tokens.iter().enumerate() {
         let token_idx: usize = token.into();
 
@@ -102,21 +105,16 @@ pub fn refresh_pyth_lazer_price<'info>(
 
         let is_frozen = oracle_mappings.is_frozen(token_idx);
 
-        {
-            let dated_price_ref = &mut oracle_prices.prices[token_idx];
-            let old_price = *dated_price_ref;
-            let mapping_generic_data = &oracle_mappings.generic[token_idx];
-            let clock = Clock::get()?;
+        let mut price = oracle_prices.prices[token_idx];
+        let mapping_generic_data = &oracle_mappings.generic[token_idx];
+        let clock = Clock::get()?;
 
-            match pyth_lazer::update_price(
-                dated_price_ref,
-                &payload_data,
-                i,
-                mapping_generic_data,
-                &clock,
-            ) {
-                Ok(()) => (),
-                Err(e) => {
+        match pyth_lazer::update_price(&mut price, &payload_data, i, mapping_generic_data, &clock) {
+            Ok(()) => (),
+            Err(e) => {
+                if fail_tx_on_error {
+                    return Err(e.into());
+                } else {
                     msg!(
                         "Price skipped as validation failed for token {token_idx}: {:?}",
                         e
@@ -124,51 +122,72 @@ pub fn refresh_pyth_lazer_price<'info>(
                     continue;
                 }
             }
+        }
 
-            // Frozen entries: log the fetched price but don't update state
-            if is_frozen {
-                msg!(
-                    "tk {} ({:?}) is frozen, fetched price {:?} but not updating",
-                    token_idx,
-                    price_type,
-                    dated_price_ref.price.value,
-                );
-                *dated_price_ref = old_price;
-                continue;
-            }
-
+        // Frozen entries: log the fetched price but don't update state
+        if is_frozen {
             msg!(
-                "tk {}, {:?}: {:?} to {:?} | prev_slot: {:?}, new_slot: {:?}, crt_slot: {:?}",
+                "tk {} ({:?}) is frozen, fetched price {:?} but not updating",
                 token_idx,
                 price_type,
-                old_price.price.value,
-                dated_price_ref.price.value,
-                old_price.last_updated_slot,
-                dated_price_ref.last_updated_slot,
-                clock.slot,
+                price.price.value,
             );
+            continue;
+        }
 
-            if oracle_mappings.is_twap_enabled(token_idx) {
-                let mut oracle_twaps = ctx.accounts.oracle_twaps.load_mut()?;
-                if let Err(e) = crate::oracles::twap::update_twaps(
-                    &mut oracle_twaps,
-                    token_idx,
-                    dated_price_ref,
-                    oracle_mappings.twap_enabled_bitmask[token_idx],
-                ) {
-                    msg!("Error while updating TWAP of token {token_idx}: {e:?}",);
+        if oracle_mappings.is_twap_enabled(token_idx) {
+            let mut oracle_twaps = ctx.accounts.oracle_twaps.load_mut()?;
+            if let Err(e) = crate::oracles::twap::update_twaps(
+                &mut oracle_twaps,
+                token_idx,
+                &price,
+                oracle_mappings.twap_enabled_bitmask[token_idx],
+            ) {
+                msg!("Error while updating TWAP of token {token_idx}: {e:?}",);
+            }
+        }
+
+        // Check that the price is close enough to the ref price if there is a ref price.
+        // Deliberately after the TWAP update: a price may use its own TWAP as its ref price (a
+        // circuit breaker filtering out short price bursts), and for that to work the TWAP must
+        // update even when the ref price check fails. In a multi-token refresh a failing token is
+        // skipped (its update not stored) so it can't block the group's other tokens; a
+        // single-token refresh fails loudly. Mirrors refresh_price_list.
+        if oracle_mappings.ref_price[token_idx] != u16::MAX {
+            let ref_price =
+                oracle_prices.prices[usize::from(oracle_mappings.ref_price[token_idx])].price;
+            let ref_price_tolerance_bps = oracle_mappings.get_ref_price_tolerance_bps(token_idx);
+            if let Err(diff_err) =
+                check_ref_price_difference(price.price, ref_price, ref_price_tolerance_bps)
+            {
+                if fail_tx_on_error {
+                    return Err(diff_err);
+                } else {
+                    msg!(
+                        "Price skipped as ref price check failed (token {token_idx}, type {price_type:?})",
+                    );
+                    continue;
                 }
             }
         }
 
-        // check that the price is close enough to the ref price if there is a ref price
-        if oracle_mappings.ref_price[token_idx] != u16::MAX {
-            let new_price = oracle_prices.prices[token_idx].price;
-            let ref_price =
-                oracle_prices.prices[usize::from(oracle_mappings.ref_price[token_idx])].price;
-            let ref_price_tolerance_bps = oracle_mappings.get_ref_price_tolerance_bps(token_idx);
-            check_ref_price_difference(new_price, ref_price, ref_price_tolerance_bps)?;
-        }
+        let to_update = oracle_prices
+            .prices
+            .get_mut(token_idx)
+            .ok_or(ScopeError::BadTokenNb)?;
+
+        msg!(
+            "tk {}, {:?}: {:?} to {:?} | prev_slot: {:?}, new_slot: {:?}, crt_slot: {:?}",
+            token_idx,
+            price_type,
+            to_update.price.value,
+            price.price.value,
+            to_update.last_updated_slot,
+            price.last_updated_slot,
+            clock.slot,
+        );
+
+        *to_update = price;
     }
 
     Ok(())

--- a/programs/scope/src/handlers/handler_resume_chainlinkx_price.rs
+++ b/programs/scope/src/handlers/handler_resume_chainlinkx_price.rs
@@ -13,9 +13,10 @@ use crate::{
 #[derive(Accounts)]
 #[instruction(token: u16, feed_name: String)]
 pub struct ResumeChainlinkXPrice<'info> {
-    pub admin: Signer<'info>,
+    #[account(constraint = configuration.load()?.can_resume(&authority.key()) @ ScopeError::UnauthorizedResume)]
+    pub authority: Signer<'info>,
 
-    #[account(seeds = [seeds::CONFIG, feed_name.as_bytes()], bump, has_one = admin, has_one = oracle_prices, has_one = oracle_mappings, has_one = tokens_metadata)]
+    #[account(seeds = [seeds::CONFIG, feed_name.as_bytes()], bump, has_one = oracle_prices, has_one = oracle_mappings, has_one = tokens_metadata)]
     pub configuration: AccountLoader<'info, Configuration>,
 
     #[account(mut, has_one = oracle_mappings)]
@@ -40,7 +41,20 @@ pub fn process(ctx: Context<ResumeChainlinkXPrice>, token: u16) -> Result<()> {
         .name;
 
     let str_name = std::str::from_utf8(&token_name).unwrap();
-    msg!("ResumeChainlinkxPrice, token: {} ({})", token, str_name);
+    // Audit trail: record who resumed and whether it was the admin or the resume delegate.
+    let authority = ctx.accounts.authority.key();
+    let authority_role = if authority == ctx.accounts.configuration.load()?.admin {
+        "admin"
+    } else {
+        "resume_authority"
+    };
+    msg!(
+        "ResumeChainlinkxPrice, token: {} ({}), authority: {} ({})",
+        token,
+        str_name,
+        authority,
+        authority_role
+    );
 
     // Check that the token at entry_id is a ChainlinkX oracle type
     let price_type: OracleType = oracle_mappings.get_entry_type(entry_id)?;

--- a/programs/scope/src/handlers/handler_set_resume_authority.rs
+++ b/programs/scope/src/handlers/handler_set_resume_authority.rs
@@ -1,0 +1,31 @@
+use anchor_lang::prelude::*;
+
+use crate::{oracles::check_context, utils::pdas::seeds};
+
+#[derive(Accounts)]
+#[instruction(new_resume_authority: Pubkey, feed_name: String)]
+pub struct SetResumeAuthority<'info> {
+    pub admin: Signer<'info>,
+
+    #[account(mut, seeds = [seeds::CONFIG, feed_name.as_bytes()], bump, has_one = admin)]
+    pub configuration: AccountLoader<'info, crate::states::configuration::Configuration>,
+}
+
+pub fn process(
+    ctx: Context<SetResumeAuthority>,
+    new_resume_authority: Pubkey,
+    feed_name: String,
+) -> Result<()> {
+    check_context(&ctx)?;
+
+    msg!(
+        "setting resume_authority to {} feed_name {}",
+        new_resume_authority,
+        feed_name
+    );
+
+    let configuration = &mut ctx.accounts.configuration.load_mut()?;
+    configuration.resume_authority = new_resume_authority;
+
+    Ok(())
+}

--- a/programs/scope/src/handlers/mod.rs
+++ b/programs/scope/src/handlers/mod.rs
@@ -10,6 +10,7 @@ pub mod handler_reset_twap;
 pub mod handler_resume_chainlinkx_price;
 pub mod handler_set_admin_cached;
 pub mod handler_set_emergency_council;
+pub mod handler_set_resume_authority;
 pub mod handler_update_mapping_and_metadata;
 
 pub use handler_approve_admin_cached::*;
@@ -24,4 +25,5 @@ pub use handler_reset_twap::*;
 pub use handler_resume_chainlinkx_price::*;
 pub use handler_set_admin_cached::*;
 pub use handler_set_emergency_council::*;
+pub use handler_set_resume_authority::*;
 pub use handler_update_mapping_and_metadata::*;

--- a/programs/scope/src/lib.rs
+++ b/programs/scope/src/lib.rs
@@ -149,4 +149,12 @@ pub mod scope {
     ) -> Result<()> {
         handler_set_emergency_council::process(ctx, new_emergency_council, feed_name)
     }
+
+    pub fn set_resume_authority(
+        ctx: Context<SetResumeAuthority>,
+        new_resume_authority: Pubkey,
+        feed_name: String,
+    ) -> Result<()> {
+        handler_set_resume_authority::process(ctx, new_resume_authority, feed_name)
+    }
 }

--- a/programs/scope/src/oracles/pyth_lazer.rs
+++ b/programs/scope/src/oracles/pyth_lazer.rs
@@ -18,9 +18,14 @@ const PYTH_LAZER_MAX_EXPONENT: u8 = 12;
 pub struct PythLazerData {
     pub feed_id: u16,
     pub exponent: u8,
-    pub confidence_factor: u32,
+    /// Tolerance factor for the bid/ask spread check (`ask - bid` against the
+    /// price). `0` disables the spread check entirely, in which case the payload
+    /// is not required to carry `BestBidPrice`/`BestAskPrice`.
+    pub bid_ask_spread_factor: u32,
     pub ema_enabled: bool,
     pub ema_confidence_factor: u32,
+    /// Tolerance factor for the native Lazer `Confidence` check; `0` disables it.
+    pub price_confidence_factor: u32,
 }
 
 impl PythLazerData {
@@ -115,6 +120,33 @@ pub fn validate_payload_data_for_group(
     Ok(())
 }
 
+/// Convert a Pyth Lazer price mantissa to `u64`, logging `what` on a negative
+/// mantissa. Prefer the `mantissa_to_u64!` macro, which fills `what` in for you.
+fn mantissa_to_u64(price: PythLazerPrice, what: &str) -> ScopeResult<u64> {
+    let mantissa: i64 = price.mantissa_i64();
+    u64::try_from(mantissa).map_err(|_| {
+        warn!(
+            "Pyth Lazer: {} mantissa {} doesn't fit in u64",
+            what, mantissa
+        );
+        ScopeError::OutOfRangeIntegralConversion
+    })
+}
+
+/// Convert a Pyth Lazer price mantissa to `u64`, deriving the log label from the
+/// passed identifier via `stringify!`. Two forms:
+/// - `mantissa_to_u64!(opt, not_present_err)` unwraps an `Option<PythLazerPrice>`
+///   (returning `not_present_err` on `None`) before converting.
+/// - `mantissa_to_u64!(price)` converts an already-unwrapped `PythLazerPrice`.
+macro_rules! mantissa_to_u64 {
+    ($opt:ident, $not_present:expr) => {
+        mantissa_to_u64($opt.ok_or($not_present)?, stringify!($opt))
+    };
+    ($price:ident) => {
+        mantissa_to_u64($price, stringify!($price))
+    };
+}
+
 pub fn validate_payload_data_for_token(
     payload_data: &PayloadData,
     feed_idx: usize,
@@ -123,9 +155,10 @@ pub fn validate_payload_data_for_token(
     let PythLazerData {
         feed_id: expected_feed_id,
         exponent: expected_exponent,
-        confidence_factor,
+        bid_ask_spread_factor,
         ema_enabled: _,
         ema_confidence_factor: _,
+        price_confidence_factor,
     } = pyth_lazer_data;
 
     // Check that the feed id is what we expect
@@ -133,11 +166,11 @@ pub fn validate_payload_data_for_token(
         return Err(ScopeError::PythLazerInvalidFeedId);
     }
 
-    // Check that the payload contains all the properties we expect: price, exponent,
-    // best bid price and best ask price
+    // Collect the feed's properties; each check below reads only the inputs it needs.
     let mut price_opt: Option<PythLazerPrice> = None;
     let mut best_bid_price_opt: Option<PythLazerPrice> = None;
     let mut best_ask_price_opt: Option<PythLazerPrice> = None;
+    let mut confidence_opt: Option<PythLazerPrice> = None;
     let mut exponent_opt: Option<i16> = None;
     let mut feed_update_timestamp_opt: Option<TimestampUs> = None;
 
@@ -152,6 +185,9 @@ pub fn validate_payload_data_for_token(
             PayloadPropertyValue::BestAskPrice(Some(price)) => {
                 best_ask_price_opt = Some(*price);
             }
+            PayloadPropertyValue::Confidence(Some(c)) => {
+                confidence_opt = Some(*c);
+            }
             PayloadPropertyValue::Exponent(exponent) => {
                 exponent_opt = Some(*exponent);
             }
@@ -164,13 +200,7 @@ pub fn validate_payload_data_for_token(
         }
     }
 
-    let pyth_lazer_price: i64 = price_opt
-        .ok_or(ScopeError::PythLazerPriceNotPresent)?
-        .mantissa_i64();
-    let pyth_lazer_price = u64::try_from(pyth_lazer_price).map_err(|_| {
-        warn!("Pyth Lazer: error converting price to u64");
-        ScopeError::OutOfRangeIntegralConversion
-    })?;
+    let pyth_lazer_price = mantissa_to_u64!(price_opt, ScopeError::PythLazerPriceNotPresent)?;
 
     let received_exponent = exponent_opt.ok_or(ScopeError::PythLazerExponentNotPresent)?;
     // Pyth Lazer sends the exponent as a negative integer, so we need to negate it
@@ -189,50 +219,64 @@ pub fn validate_payload_data_for_token(
         exp: exponent_u64,
     };
 
-    let best_bid_price: i64 = best_bid_price_opt
-        .ok_or(ScopeError::PythLazerBestBidPriceNotPresent)?
-        .mantissa_i64();
-    let best_bid_price = u64::try_from(best_bid_price).map_err(|_| {
-        warn!("Pyth Lazer: error converting best bid price to u64");
-        ScopeError::OutOfRangeIntegralConversion
-    })?;
-    let best_bid_price = Price {
-        value: best_bid_price,
-        exp: exponent_u64,
-    };
+    // Bid/ask spread check. When the factor is 0 the check is disabled, and the
+    // payload is neither required to carry bid/ask nor inspected for them (feeds
+    // such as NAV/redemption rates publish no bid/ask).
+    if *bid_ask_spread_factor > 0 {
+        let best_bid_price = mantissa_to_u64!(
+            best_bid_price_opt,
+            ScopeError::PythLazerBestBidPriceNotPresent
+        )?;
 
-    let best_ask_price: i64 = best_ask_price_opt
-        .ok_or(ScopeError::PythLazerBestAskPriceNotPresent)?
-        .mantissa_i64();
-    let best_ask_price = u64::try_from(best_ask_price).map_err(|_| {
-        warn!("Pyth Lazer: error converting best ask price to u64");
-        ScopeError::OutOfRangeIntegralConversion
-    })?;
-    let best_ask_price = Price {
-        value: best_ask_price,
-        exp: exponent_u64,
-    };
+        let best_ask_price = mantissa_to_u64!(
+            best_ask_price_opt,
+            ScopeError::PythLazerBestAskPriceNotPresent
+        )?;
 
-    let spread_value_opt = best_ask_price.value.checked_sub(best_bid_price.value);
-    if spread_value_opt.is_none() {
-        return Err(ScopeError::PythLazerInvalidAskBidPrices);
+        let spread_value = best_ask_price
+            .checked_sub(best_bid_price)
+            .ok_or(ScopeError::PythLazerInvalidAskBidPrices)?;
+
+        check_confidence_interval(
+            u128::from(new_price.value),
+            u32::from(*expected_exponent),
+            u128::from(spread_value),
+            u32::from(*expected_exponent),
+            *bid_ask_spread_factor,
+        )
+        .map_err(|e| {
+            warn!(
+                "PythLazer provided a price '{}' with bid '{best_bid_price}' and ask \
+                '{best_ask_price}' not fitting the configured '{bid_ask_spread_factor}' \
+                bid/ask spread factor",
+                new_price.value,
+            );
+            e
+        })?;
     }
 
-    check_confidence_interval(
-        u128::from(new_price.value),
-        u32::from(*expected_exponent),
-        u128::from(spread_value_opt.unwrap()),
-        u32::from(*expected_exponent),
-        *confidence_factor,
-    )
-    .map_err(|e| {
-        warn!(
-            "PythLazer provided a price '{}' with bid '{}' and ask '{}' not fitting the \
-            configured '{confidence_factor}' confidence factor",
-            new_price.value, best_bid_price.value, best_ask_price.value,
-        );
-        e
-    })?;
+    // Native Lazer confidence check. When the factor is 0 the check is disabled,
+    // and the payload is not required to carry a `Confidence` property.
+    if *price_confidence_factor > 0 {
+        let confidence_value =
+            mantissa_to_u64!(confidence_opt, ScopeError::PythLazerConfidenceNotPresent)?;
+
+        check_confidence_interval(
+            u128::from(new_price.value),
+            u32::from(*expected_exponent),
+            u128::from(confidence_value),
+            u32::from(*expected_exponent),
+            *price_confidence_factor,
+        )
+        .map_err(|e| {
+            warn!(
+                "PythLazer provided a price '{}' with confidence '{confidence_value}' not fitting \
+                the configured '{price_confidence_factor}' price confidence factor",
+                new_price.value,
+            );
+            e
+        })?;
+    }
 
     let feed_update_timestamp =
         feed_update_timestamp_opt.ok_or(ScopeError::PythLazerFeedUpdateTimestampNotPresent)?;
@@ -332,34 +376,25 @@ fn extract_ema_from_payload(
     payload_data: &PayloadData,
     feed_idx: usize,
 ) -> ScopeResult<Option<PythLazerEmaPayload>> {
-    let mut value_opt: Option<u64> = None;
-    let mut confidence: Option<u64> = None;
+    let mut ema_price_opt: Option<PythLazerPrice> = None;
+    let mut ema_confidence_opt: Option<PythLazerPrice> = None;
     for property in payload_data.feeds[feed_idx].properties.iter() {
         match property {
-            PayloadPropertyValue::EmaPrice(Some(price)) => {
-                let mantissa: i64 = price.mantissa_i64();
-                let value = u64::try_from(mantissa).map_err(|_| {
-                    warn!("Pyth Lazer: EMA mantissa {mantissa} doesn't fit in u64");
-                    ScopeError::MathOverflow
-                })?;
-                value_opt = Some(value);
-            }
-            PayloadPropertyValue::EmaConfidence(Some(price)) => {
-                let mantissa: i64 = price.mantissa_i64();
-                let conf = u64::try_from(mantissa).map_err(|_| {
-                    warn!("Pyth Lazer: EMA confidence {mantissa} doesn't fit in u64");
-                    ScopeError::MathOverflow
-                })?;
-                confidence = Some(conf);
-            }
+            PayloadPropertyValue::EmaPrice(Some(price)) => ema_price_opt = Some(*price),
+            PayloadPropertyValue::EmaConfidence(Some(price)) => ema_confidence_opt = Some(*price),
             _ => continue,
         }
     }
 
-    match value_opt {
-        Some(value) => Ok(Some(PythLazerEmaPayload { value, confidence })),
-        None => Ok(None),
-    }
+    let Some(ema_price) = ema_price_opt else {
+        return Ok(None);
+    };
+    let value = mantissa_to_u64!(ema_price)?;
+    let confidence = match ema_confidence_opt {
+        Some(ema_confidence) => Some(mantissa_to_u64!(ema_confidence)?),
+        None => None,
+    };
+    Ok(Some(PythLazerEmaPayload { value, confidence }))
 }
 
 fn validate_ema_confidence(
@@ -459,13 +494,14 @@ pub fn validate_mapping_cfg(mapping: Option<&AccountInfo>, generic_data: &[u8]) 
     let PythLazerData {
         feed_id,
         exponent,
-        confidence_factor,
+        bid_ask_spread_factor,
         ema_enabled,
         ema_confidence_factor,
+        price_confidence_factor,
     } = PythLazerData::from_generic_data(generic_data)?;
 
     msg!(
-        "Pyth Lazer: validating mapping with feed_id = {feed_id}, exponent = {exponent}, confidence_factor = {confidence_factor}, ema_enabled = {ema_enabled}, ema_confidence_factor = {ema_confidence_factor}",
+        "Pyth Lazer: validating mapping with feed_id = {feed_id}, exponent = {exponent}, bid_ask_spread_factor = {bid_ask_spread_factor}, ema_enabled = {ema_enabled}, ema_confidence_factor = {ema_confidence_factor}, price_confidence_factor = {price_confidence_factor}",
     );
 
     if feed_id == 0 {
@@ -476,7 +512,8 @@ pub fn validate_mapping_cfg(mapping: Option<&AccountInfo>, generic_data: &[u8]) 
         return Err(ScopeError::PythLazerInvalidExponent);
     }
 
-    if confidence_factor < 1 {
+    if price_confidence_factor < 1 {
+        // bid/ask spread check is optional (0 disables it)
         return Err(ScopeError::PythLazerInvalidConfidenceFactor);
     }
 

--- a/programs/scope/src/states/configuration.rs
+++ b/programs/scope/src/states/configuration.rs
@@ -10,5 +10,24 @@ pub struct Configuration {
     pub oracle_twaps: Pubkey,
     pub admin_cached: Pubkey,
     pub emergency_council: Pubkey,
-    _padding: [u64; 1251],
+    pub resume_authority: Pubkey,
+    _padding: [u64; 1247],
+}
+
+impl Configuration {
+    /// Admin can always resume; the `resume_authority` can resume only once it is set.
+    pub fn can_resume(&self, key: &Pubkey) -> bool {
+        *key == self.admin || is_active_delegate(&self.resume_authority, key)
+    }
+
+    /// Admin can freeze and unfreeze; the `emergency_council` can only freeze.
+    pub fn can_freeze(&self, key: &Pubkey, freeze: bool) -> bool {
+        *key == self.admin || (freeze && is_active_delegate(&self.emergency_council, key))
+    }
+}
+
+/// A delegate authority counts as active only once it has been set to a
+/// non-default pubkey; an unset (default) delegate grants no rights.
+fn is_active_delegate(delegate: &Pubkey, key: &Pubkey) -> bool {
+    *delegate != Pubkey::default() && delegate == key
 }


### PR DESCRIPTION
**Audited by OtterSec**

- Add resume_authority to scope feed config
- Add native Confidence check for Pyth Lazer and make bid/ask spread check optional
- Skip tokens failing the ref price check in refresh_pyth_lazer_price instead of failing the tx